### PR TITLE
`ValueError` when reporting on running jobs

### DIFF
--- a/src/fractal_slurm_tools/parse_sacct_info.py
+++ b/src/fractal_slurm_tools/parse_sacct_info.py
@@ -62,7 +62,7 @@ def get_job_submit_start_end_times(
             job_Submit = main_job_line_fields[INDEX_JOB_SUBMIT]
             job_Start = main_job_line_fields[INDEX_JOB_START]
             job_End = main_job_line_fields[INDEX_JOB_END]
-            if job_Start != "None":
+            try:
                 job_queue_time = (
                     _isoformat_to_datetime(job_Start)
                     - _isoformat_to_datetime(job_Submit)
@@ -71,7 +71,7 @@ def get_job_submit_start_end_times(
                     _isoformat_to_datetime(job_End)
                     - _isoformat_to_datetime(job_Start)
                 ).total_seconds()
-            else:
+            except ValueError:
                 job_queue_time = 0
                 job_runtime = 0
 


### PR DESCRIPTION
closes #23 